### PR TITLE
Add Terraform Apply Job to Workflow

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -147,35 +147,33 @@ jobs:
                 body: body
             })
 
-  deploy:
-    name: Deploy
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  # This will only run if the terraform plan has changes, and when the PR is approved and merged to main.
+  terraform-apply:
+    name: 'Terraform Apply'
+    if: github.ref == 'refs/heads/main' && needs.terraform-plan.outputs.tfplanExitCode == 2
     runs-on: ubuntu-latest
     environment: production
-    needs: [integration-test]
-
-    defaults:
-      run:
-        working-directory: ./infra/tf-app
-
+    needs: [terraform-plan]
+    
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v4
 
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "1.5.0"
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      run: terraform init
 
-      - name: Terraform Init
-        run: terraform init
+    # Download saved plan from artifacts  
+    - name: Download Terraform Plan
+      uses: actions/download-artifact@v4
+      with:
+        name: tfplan
 
-      - name: Terraform Apply
-        run: terraform apply -auto-approve
+    # Terraform Apply
+    - name: Terraform Apply
+      run: terraform apply -auto-approve tfplan


### PR DESCRIPTION
This PR adds the terraform-apply job to match lab requirements:

1. Terraform Apply Job:
   - Only runs on main branch when plan has changes
   - Uses production environment for proper permissions
   - Downloads and applies saved plan from artifacts
   - Depends on terraform-plan job success
   - Requires approval via environment protection rules

2. Workflow Configuration:
   - Added proper job dependencies
   - Added artifact handling
   - Added environment protection
   - Added proper condition checks

Testing Checklist:
- [ ] TFLint runs successfully
- [ ] Terraform plan generates and saves artifact
- [ ] Plan shows in PR comments
- [ ] Apply job triggers only on main with changes

Required Reviewers:
- @thoufeekx