### PR TITLE
Fix Terraform Version Compatibility

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -71,6 +71,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
       with:
+        terraform_version: "1.5.0"
         terraform_wrapper: false
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
@@ -163,6 +164,8 @@ jobs:
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: "1.5.0"
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init


### PR DESCRIPTION
This PR fixes Terraform version compatibility issues:

1. Version Fixes:
   - Set terraform_version: 1.5.0 in all workflow jobs
   - Match version with terraform.tf requirement (~> 1.5.0)
   - Fix unsupported version error (was using 1.11.3)

2. Workflow Jobs:
   - terraform-plan job uses 1.5.0
   - terraform-apply job uses 1.5.0
   - All jobs match terraform.tf requirements

Testing Checklist:
- [ ] Terraform init works with version 1.5.0
- [ ] Plan generates without version errors
- [ ] Apply job uses correct version

Required Reviewers:
- @thoufeekx