### PR TITLE
Fix OIDC token handling in workflow

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -16,7 +16,6 @@ env:
   ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
   ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
   ARM_USE_OIDC: true
-  ARM_OIDC_TOKEN: "${{ steps.azure-login.outputs.access_token }}"
   ARM_ACCESS_KEY: "${{ secrets.ARM_ACCESS_KEY }}"
 
 defaults:
@@ -85,6 +84,10 @@ jobs:
       with:
         terraform_version: "1.5.0"
         terraform_wrapper: false
+
+    # Set OIDC token after Azure login
+    - name: Set OIDC Token
+      run: echo "ARM_OIDC_TOKEN=${{ steps.azure-login.outputs.access_token }}" >> $GITHUB_ENV
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
@@ -192,6 +195,10 @@ jobs:
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: "1.5.0"
+
+    # Set OIDC token after Azure login
+    - name: Set OIDC Token
+      run: echo "ARM_OIDC_TOKEN=${{ steps.azure-login.outputs.access_token }}" >> $GITHUB_ENV
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init


### PR DESCRIPTION
This PR fixes the OIDC token handling in the CI/CD workflow:

1. OIDC Token:
   - Move ARM_OIDC_TOKEN to be set after Azure login
   - Add Set OIDC Token step in each job
   - Fix invalid workflow error with steps reference

2. Authentication Flow:
   - Azure login first
   - Capture access token
   - Set as environment variable
   - Use for Terraform operations

3. Job Structure:
   - Each job handles its own OIDC token
   - Proper step dependencies
   - Clean environment variable handling

Testing Checklist:
- [ ] Workflow validation passes
- [ ] Azure login works
- [ ] OIDC token is properly set
- [ ] Terraform can authenticate

Required Reviewers:
- @thoufeekx