### PR TITLE
Fix Terraform backend authentication

### DIFF
--- a/infra/tf-app/terraform.tf
+++ b/infra/tf-app/terraform.tf
@@ -11,7 +11,6 @@ terraform {
     storage_account_name = "sa040982662githubactions"
     container_name       = "tfstate"
     key                  = "prod.app.tfstate"
-    use_oidc             = true
   }
 }
 


### PR DESCRIPTION
This PR fixes the Terraform backend authentication:

1. Backend Configuration:
   - Remove use_oidc from backend config
   - Use storage account key for state access
   - Fix authentication errors

2. Authentication Flow:
   - Use OIDC for Azure resource management
   - Use storage account key for state backend
   - Proper secret handling

Testing Checklist:
- [ ] Terraform init works
- [ ] State backend is accessible
- [ ] Azure authentication works

Required Reviewers:
- @thoufeekx