### PR TITLE
Update terraform-apply job to match lab requirements

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -181,26 +181,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    # Azure Login
-    - name: Azure Login
-      id: azure-login
-      uses: azure/login@v1
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        enable-AzPSSession: false
-        audience: api://AzureADTokenExchange
-
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: "1.5.0"
-
-    # Set OIDC token after Azure login
-    - name: Set OIDC Token
-      run: echo "ARM_OIDC_TOKEN=${{ steps.azure-login.outputs.access_token }}" >> $GITHUB_ENV
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init


### PR DESCRIPTION
This PR updates the terraform-apply job to match the lab requirements exactly:

1. Job Configuration:
   - Runs only on merge to main
   - Uses production environment
   - Depends on terraform-plan job
   - Requires plan to have changes

2. Steps:
   - Checkout code
   - Setup Terraform
   - Initialize Terraform
   - Download and apply plan

3. Simplifications:
   - Remove redundant Azure login
   - Streamline Terraform setup
   - Match lab configuration exactly

Testing Checklist:
- [ ] Workflow triggers correctly
- [ ] Environment protection works
- [ ] Plan applies successfully

Required Reviewers:
- @thoufeekx