### PR TITLE
Add infrastructure elements

### DIFF
--- a/infra/tf-app/main.tf
+++ b/infra/tf-app/main.tf
@@ -4,3 +4,20 @@ resource "azurerm_resource_group" "rg" {
   location = "canadacentral"
   tags     = var.tags
 }
+
+# Virtual Network
+resource "azurerm_virtual_network" "vnet" {
+  name                = "040982662-a12-vnet"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = ["10.0.0.0/16"]
+  tags                = var.tags
+}
+
+# Subnet
+resource "azurerm_subnet" "subnet" {
+  name                 = "040982662-a12-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+}


### PR DESCRIPTION
This PR adds new infrastructure elements to our Terraform configuration:

1. Virtual Network:
   - Name: 040982662-a12-vnet
   - Address Space: 10.0.0.0/16
   - Located in Canada Central
   - Inherits resource group tags

2. Subnet:
   - Name: 040982662-a12-subnet
   - Address Range: 10.0.1.0/24
   - Part of the new VNet

Testing Checklist:
- [ ] Static analysis passes
- [ ] Terraform plan shows expected changes
- [ ] Resources are properly tagged
- [ ] Network addressing is correct

Required Reviewers:
- @thoufeekx