### PR TITLE
Fix Azure authorization in apply job

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -181,6 +181,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    # Azure Login
+    - name: Azure Login
+      id: azure-login
+      uses: azure/login@v1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        enable-AzPSSession: false
+        audience: api://AzureADTokenExchange
+
+    # Set OIDC Token
+    - name: Set OIDC Token
+      run: echo "ARM_OIDC_TOKEN=${{ steps.azure-login.outputs.access_token }}" >> $GITHUB_ENV
+
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
This PR fixes the Azure authorization error in the apply job:

1. Authentication Fixes:
   - Add Azure login step with correct audience parameter
   - Set OIDC token for Terraform
   - Fix 403 Forbidden error

2. Changes:
   - Added Azure login step before Terraform operations
   - Set audience to 'api://AzureADTokenExchange'
   - Pass OIDC token to Terraform

Testing Checklist:
- [ ] Azure login works
- [ ] Terraform has proper authorization
- [ ] Resources can be created

Required Reviewers:
- @thoufeekx