### PR TITLE
Fix: Add audience parameter for Azure OIDC login

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -43,6 +43,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: false
+          audience: api://AzureADTokenExchange
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
This PR fixes the Azure OIDC login issue by:

1. Adding the required 'audience' parameter to the Azure login action
2. Setting it to 'api://AzureADTokenExchange' to match our federated credentials

This should resolve the Azure login error in our GitHub Actions workflow.