### PR TITLE
Add allow-no-subscriptions parameter to Azure login

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -46,6 +46,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: false
           audience: api://AzureADTokenExchange
+          allow-no-subscriptions: true
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
This PR adds the allow-no-subscriptions parameter to fix the Azure login error:

1. Added allow-no-subscriptions: true to Azure login action
2. This should fix the 'No subscriptions found' error
3. Allows the workflow to proceed even if no subscriptions are found

This change is based on the Azure login action documentation which suggests using this parameter when encountering subscription-related issues.