### PR TITLE
Update Azure login with correct subscription ID

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -43,10 +43,9 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          subscription-id: "5eb83737-e0c8-46c1-818d-4d9725820e3f"
           enable-AzPSSession: false
           audience: api://AzureADTokenExchange
-          allow-no-subscriptions: true
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -132,10 +131,9 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          subscription-id: "5eb83737-e0c8-46c1-818d-4d9725820e3f"
           enable-AzPSSession: false
           audience: api://AzureADTokenExchange
-          allow-no-subscriptions: true
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
This PR updates the Azure login configuration with the correct subscription ID:

1. Removed AZURE_SUBSCRIPTION_ID secret dependency
2. Added explicit subscription ID: 5eb83737-e0c8-46c1-818d-4d9725820e3f
3. Removed allow-no-subscriptions as we now have a valid subscription

This change ensures we're using the correct subscription that has been verified to work with az login.