### PR TITLE
Fix Terraform plan artifact handling

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -115,6 +115,7 @@ jobs:
             })
 
   apply:
+    needs: plan
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Terraform Apply
@@ -147,7 +148,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: tfplan
-          path: ./infra/tf-app
+          path: ./infra/tf-app/tfplan
 
       - name: Terraform Apply
         run: terraform apply -auto-approve tfplan


### PR DESCRIPTION
This PR fixes the Terraform plan artifact handling:

1. Added dependency between apply and plan jobs using 'needs: plan'
2. Fixed the artifact download path to match the upload path

These changes ensure the Terraform plan is properly passed between jobs.