### PR TITLE
Update workflow conditions

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -24,7 +24,6 @@ defaults:
 
 jobs:
   plan:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     name: Terraform Plan
     environment:
@@ -116,7 +115,7 @@ jobs:
 
   apply:
     needs: plan
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     name: Terraform Apply
     environment:


### PR DESCRIPTION
This PR updates the workflow conditions to run properly:

1. Removed condition that limited plan job to only pull requests
2. Simplified apply job condition to only check for main branch
3. Plan job will now run on both pull requests and pushes
4. Apply job will run on main branch after plan succeeds

These changes ensure the workflow runs when needed and doesn't get skipped unnecessarily.