### PR TITLE
Fix artifact handling and working directory issues

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -21,7 +21,8 @@ env:
 
 defaults:
   run:
-    working-directory: ./infra/tf-app  
+    shell: bash
+    working-directory: ./infra/tf-app
 
 jobs:
   plan:
@@ -32,6 +33,7 @@ jobs:
       url: ${{ github.server_url }}/${{ github.repository }}/deployments
     defaults:
       run:
+        shell: bash
         working-directory: ./infra/tf-app
 
     steps:
@@ -77,10 +79,12 @@ jobs:
           fi
 
       - name: Publish Terraform Plan Artifact
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: tfplan
-          path: ./infra/tf-app/tfplan
+          path: tfplan
+          retention-days: 1
 
       - name: Create String Output
         id: tf-plan-string
@@ -153,7 +157,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: tfplan
-          path: ./infra/tf-app/tfplan
+          path: .
+
+      - name: List Files
+        run: ls -la
 
       - name: Terraform Apply
         run: |


### PR DESCRIPTION
This PR fixes the artifact handling and working directory issues:

1. Updated artifact paths to be relative to working directory
2. Added explicit shell configuration (bash)
3. Added success() condition for artifact upload
4. Added file listing step for debugging
5. Set artifact retention to 1 day
6. Simplified artifact paths in both jobs

These changes should fix the artifact download errors in the workflow.