### PR TITLE
Simplify workflow by removing artifact handling

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -64,27 +64,12 @@ jobs:
       - name: Terraform Plan
         id: tf-plan
         run: |
-          export exitcode=0
           terraform plan \
             -var="client_id=$ARM_CLIENT_ID" \
             -var="client_secret=${{ secrets.ARM_CLIENT_SECRET }}" \
             -var="subscription_id=$ARM_SUBSCRIPTION_ID" \
             -var="tenant_id=$ARM_TENANT_ID" \
-            -detailed-exitcode -no-color -out=plan.tfplan || export exitcode=$?
-
-          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
-          if [ $exitcode -eq 1 ]; then
-            echo "Terraform Plan Failed!"
-            exit 1
-          fi
-
-      - name: Publish Terraform Plan Artifact
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: tfplan
-          path: plan.tfplan
-          if-no-files-found: error
+            -input=false
 
       - name: Create String Output
         id: tf-plan-string
@@ -153,20 +138,13 @@ jobs:
       - name: Terraform Init
         run: terraform init
 
-      - name: Download Terraform Plan
-        uses: actions/download-artifact@v4
-        with:
-          name: tfplan
-          path: .
-
-      - name: List Files
-        run: ls -la
-
-      - name: Terraform Apply
+      - name: Terraform Plan and Apply
         run: |
-          terraform apply \
+          terraform plan \
             -var="client_id=$ARM_CLIENT_ID" \
             -var="client_secret=${{ secrets.ARM_CLIENT_SECRET }}" \
             -var="subscription_id=$ARM_SUBSCRIPTION_ID" \
             -var="tenant_id=$ARM_TENANT_ID" \
-            -auto-approve plan.tfplan
+            -input=false -out=tfplan
+
+          terraform apply -auto-approve tfplan


### PR DESCRIPTION
This PR simplifies the workflow by removing artifact handling:

1. Removed artifact upload/download steps
2. Plan job now just runs terraform plan to validate changes
3. Apply job now runs both plan and apply in sequence
4. Added -input=false to prevent prompts
5. Simplified the overall workflow

These changes make the workflow more reliable by avoiding artifact handling issues.