### PR TITLE
Fix plan output and string generation

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -69,19 +69,18 @@ jobs:
             -var="client_secret=${{ secrets.ARM_CLIENT_SECRET }}" \
             -var="subscription_id=$ARM_SUBSCRIPTION_ID" \
             -var="tenant_id=$ARM_TENANT_ID" \
-            -input=false
+            -input=false -no-color | tee plan_output.txt
 
       - name: Create String Output
         id: tf-plan-string
         run: |
-          TERRAFORM_PLAN=$(terraform show -no-color tfplan)
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
           echo "## Terraform Plan Output" >> $GITHUB_OUTPUT
           echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo '```terraform' >> $GITHUB_OUTPUT
-          echo "$TERRAFORM_PLAN" >> $GITHUB_OUTPUT
+          cat plan_output.txt >> $GITHUB_OUTPUT
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR fixes the plan output and string generation:

1. Changed plan output to be captured directly using tee
2. Removed dependency on tfplan file
3. Use plan_output.txt for PR comments
4. Simplified the string generation process

These changes ensure the plan output is properly captured and displayed in PR comments.