### PR TITLE
Add TFLint job to CI/CD pipeline

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -25,6 +25,29 @@ defaults:
     working-directory: ./infra/tf-app
 
 jobs:
+  tflint:
+    name: TFLint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./infra/tf-app
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.50.0
+
+      - name: Initialize TFLint
+        run: tflint --init
+
+      - name: Run TFLint
+        run: tflint -f compact
+
   static:
     name: Static Analysis
     runs-on: ubuntu-latest
@@ -134,7 +157,7 @@ jobs:
             })
 
   apply:
-    needs: [plan, static]
+    needs: [plan, static, tflint]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     name: Terraform Apply


### PR DESCRIPTION
This PR adds TFLint to the CI/CD pipeline:

1. Added a new 'tflint' job that runs in parallel with 'plan' and 'static'
2. TFLint job:
   - Uses terraform-linters/setup-tflint@v4
   - Runs with both terraform and azurerm rulesets
   - Checks for best practices and potential issues
3. Updated 'apply' job to require all three jobs to pass:
   - plan (infrastructure changes)
   - static (format and validation)
   - tflint (linting and best practices)

This adds another layer of quality control to ensure our Terraform code follows best practices.