### PR TITLE
Fix Azure login in drift detection job

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -49,8 +49,13 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: false
-          audience: api://AzureADTokenExchange
-          allow-no-subscriptions: true
+
+      - name: Set Environment Variables
+        run: |
+          echo "ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> $GITHUB_ENV
+          echo "ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
+          echo "ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}" >> $GITHUB_ENV
+          echo "ARM_USE_OIDC=true" >> $GITHUB_ENV
 
       - name: Terraform Init
         run: terraform init


### PR DESCRIPTION
This PR fixes the Azure login in the drift detection job:

1. Removed problematic audience and allow-no-subscriptions parameters
2. Added environment variables for Terraform OIDC auth:
   - ARM_CLIENT_ID
   - ARM_SUBSCRIPTION_ID
   - ARM_TENANT_ID
   - ARM_USE_OIDC
3. Matches the working configuration from plan job

This should fix the authentication issues in the drift detection job.