### PR TITLE
Update federated credential subject

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -57,6 +57,8 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: false
+          audience: api://AzureADTokenExchange
+          subject: repo:akhiljos256/cst8918-w25-lab12:ref:refs/heads/${{ github.ref_name }}
 
       - name: Terraform Init
         run: terraform init


### PR DESCRIPTION
This PR updates the federated credential configuration:

1. Added explicit audience parameter: api://AzureADTokenExchange
2. Added dynamic subject that works for both main and dev branches:
   `repo:akhiljos256/cst8918-w25-lab12:ref:refs/heads/${github.ref_name}`

This ensures the Azure login works correctly regardless of which branch the workflow runs on.