### PR TITLE
Update Azure login to use dynamic subject based on branch

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -50,6 +50,7 @@ jobs:
           subscription-id: "5eb83737-e0c8-46c1-818d-4d9725820e3f"
           enable-AzPSSession: false
           audience: api://AzureADTokenExchange
+          subject: repo:akhiljos256/cst8918-w25-lab12:ref:refs/heads/${{ github.ref_name }}
 
       - name: Terraform Init
         run: terraform init
@@ -144,6 +145,7 @@ jobs:
           subscription-id: "5eb83737-e0c8-46c1-818d-4d9725820e3f"
           enable-AzPSSession: false
           audience: api://AzureADTokenExchange
+          subject: repo:akhiljos256/cst8918-w25-lab12:ref:refs/heads/${{ github.ref_name }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -224,6 +226,7 @@ jobs:
           subscription-id: "5eb83737-e0c8-46c1-818d-4d9725820e3f"
           enable-AzPSSession: false
           audience: api://AzureADTokenExchange
+          subject: repo:akhiljos256/cst8918-w25-lab12:ref:refs/heads/${{ github.ref_name }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
This PR updates the Azure login configuration to use dynamic federated credentials:

1. Added federated credentials for both branches:
   - main: repo:akhiljos256/cst8918-w25-lab12:ref:refs/heads/main
   - dev: repo:akhiljos256/cst8918-w25-lab12:ref:refs/heads/dev

2. Updated workflow to use dynamic subject:
   `subject: repo:akhiljos256/cst8918-w25-lab12:ref:refs/heads/${{ github.ref_name }}`

This ensures the Azure login works correctly on both main and dev branches by using the appropriate federated credential based on the current branch.